### PR TITLE
Added support for file globs in source_directories.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -3,6 +3,7 @@
  * Fixed handling of repeated spaces in source_directories which resulted in backup up everything.
  * Added support for --one-file-system for Borg.
  * Support borg create --umask.
+ * Added support for file globs in source_directories.
 
 0.1.7
 

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Here's an example config file:
 ```INI
 [location]
 # Space-separated list of source directories to backup.
-source_directories: /home /etc
-# source_directories_glob: 1
+# Globs are expanded.
+source_directories: /home /etc /var/log/syslog*
 
 # Path to local or remote backup repository.
 repository: user@backupserver:sourcehostname.attic

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Here's an example config file:
 [location]
 # Space-separated list of source directories to backup.
 source_directories: /home /etc
+# source_directories_glob: 1
 
 # Path to local or remote backup repository.
 repository: user@backupserver:sourcehostname.attic

--- a/atticmatic/backends/shared.py
+++ b/atticmatic/backends/shared.py
@@ -3,6 +3,8 @@ import os
 import re
 import platform
 import subprocess
+from glob import glob
+from itertools import chain
 
 from atticmatic.config import Section_format, option
 from atticmatic.verbosity import VERBOSITY_SOME, VERBOSITY_LOTS
@@ -19,6 +21,7 @@ CONFIG_FORMAT = (
         'location',
         (
             option('source_directories'),
+            option('source_directories_glob', int, required=False),
             option('repository'),
         ),
     ),
@@ -58,7 +61,7 @@ def initialize(storage_config, command):
 
 def create_archive(
     excludes_filename, verbosity, storage_config, source_directories, repository, command,
-    one_file_system=None,
+    one_file_system=None, source_directories_glob=None
 ):
     '''
     Given an excludes filename (or None), a vebosity flag, a storage config dict, a space-separated
@@ -66,6 +69,8 @@ def create_archive(
     attic archive.
     '''
     sources = tuple(re.split('\s+', source_directories))
+    if source_directories_glob:
+        sources = tuple(chain.from_iterable([glob(x) for x in sources]))
     exclude_flags = ('--exclude-from', excludes_filename) if excludes_filename else ()
     compression = storage_config.get('compression', None)
     compression_flags = ('--compression', compression) if compression else ()

--- a/atticmatic/backends/shared.py
+++ b/atticmatic/backends/shared.py
@@ -21,7 +21,6 @@ CONFIG_FORMAT = (
         'location',
         (
             option('source_directories'),
-            option('source_directories_glob', int, required=False),
             option('repository'),
         ),
     ),
@@ -61,16 +60,15 @@ def initialize(storage_config, command):
 
 def create_archive(
     excludes_filename, verbosity, storage_config, source_directories, repository, command,
-    one_file_system=None, source_directories_glob=None
+    one_file_system=None
 ):
     '''
     Given an excludes filename (or None), a vebosity flag, a storage config dict, a space-separated
     list of source directories, a local or remote repository path, and a command to run, create an
     attic archive.
     '''
-    sources = tuple(re.split('\s+', source_directories))
-    if source_directories_glob:
-        sources = tuple(chain.from_iterable([glob(x) for x in sources]))
+    sources = re.split('\s+', source_directories)
+    sources = tuple(chain.from_iterable([glob(x) if glob(x) else [x] for x in sources]))
     exclude_flags = ('--exclude-from', excludes_filename) if excludes_filename else ()
     compression = storage_config.get('compression', None)
     compression_flags = ('--compression', compression) if compression else ()

--- a/atticmatic/tests/unit/backends/test_shared.py
+++ b/atticmatic/tests/unit/backends/test_shared.py
@@ -177,6 +177,22 @@ def test_create_archive_with_umask_should_call_attic_with_umask_parameters():
     )
 
 
+def test_create_archive_with_globs():
+    insert_subprocess_mock(('attic', 'create', 'repo::host-now', 'setup.py', 'setup.cfg'))
+    insert_platform_mock()
+    insert_datetime_mock()
+
+    module.create_archive(
+        excludes_filename=None,
+        verbosity=None,
+        storage_config={},
+        source_directories='setup*',
+        repository='repo',
+        command='attic',
+        source_directories_glob=1,
+    )
+
+
 BASE_PRUNE_FLAGS = (
     ('--keep-daily', '1'),
     ('--keep-weekly', '2'),

--- a/atticmatic/tests/unit/backends/test_shared.py
+++ b/atticmatic/tests/unit/backends/test_shared.py
@@ -189,7 +189,6 @@ def test_create_archive_with_globs():
         source_directories='setup*',
         repository='repo',
         command='attic',
-        source_directories_glob=1,
     )
 
 

--- a/sample/config
+++ b/sample/config
@@ -1,7 +1,7 @@
 [location]
 # Space-separated list of source directories to backup.
-source_directories: /home /etc
-# source_directories_glob: 1
+# Globs are expanded.
+source_directories: /home /etc /var/log/syslog*
 
 # For Borg only, you can specify to stay in same file system (do not cross
 # mount points).

--- a/sample/config
+++ b/sample/config
@@ -1,6 +1,7 @@
 [location]
 # Space-separated list of source directories to backup.
 source_directories: /home /etc
+# source_directories_glob: 1
 
 # For Borg only, you can specify to stay in same file system (do not cross
 # mount points).


### PR DESCRIPTION
`source_directories_glob` can be used to enable glob support (defaults to
disabled). Let me know what needs to be changed (option names or other stuff) for this patch to get accepted.