### PR TITLE
Use /\s+/ to split source_directories to handle 1+ spaces.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+0.1.8-dev
+
+ * Fixed handling of repeated spaces in source_directories which resulted in backup up everything.
+
 0.1.7
 
  * #11: Fixed parsing of punctuation in configuration file.

--- a/atticmatic/backends/shared.py
+++ b/atticmatic/backends/shared.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 import os
+import re
 import platform
 import subprocess
 
@@ -63,7 +64,7 @@ def create_archive(
     list of source directories, a local or remote repository path, and a command to run, create an
     attic archive.
     '''
-    sources = tuple(source_directories.split(' '))
+    sources = tuple(re.split('\s+', source_directories))
     exclude_flags = ('--exclude-from', excludes_filename) if excludes_filename else ()
     compression = storage_config.get('compression', None)
     compression_flags = ('--compression', compression) if compression else ()
@@ -167,7 +168,7 @@ def _make_check_flags(checks, check_last=None):
         ('repository',)
 
     This will be returned as:
-    
+
         ('--repository-only',)
 
     Additionally, if a check_last value is given, a "--last" flag will be added. Note that only

--- a/atticmatic/tests/unit/backends/test_shared.py
+++ b/atticmatic/tests/unit/backends/test_shared.py
@@ -71,6 +71,21 @@ def test_create_archive_should_call_attic_with_parameters():
     )
 
 
+def test_create_archive_with_two_spaces_in_source_directories():
+    insert_subprocess_mock(CREATE_COMMAND)
+    insert_platform_mock()
+    insert_datetime_mock()
+
+    module.create_archive(
+        excludes_filename='excludes',
+        verbosity=None,
+        storage_config={},
+        source_directories='foo  bar',
+        repository='repo',
+        command='attic',
+    )
+
+
 def test_create_archive_with_none_excludes_filename_should_call_attic_without_excludes():
     insert_subprocess_mock(CREATE_COMMAND_WITHOUT_EXCLUDES)
     insert_platform_mock()


### PR DESCRIPTION
This bug is can be quite annoying because when you accidentally used
something like:

```ini
[location]
source_directories: backup_one  backup_two
;                              A (Additional space here)
```

It would call Attic/Borg with ('backup_one', '', 'backup_two') which in
turn backups your whole $PWD.